### PR TITLE
Fixed erroneous repo kind

### DIFF
--- a/frontmatter.yml
+++ b/frontmatter.yml
@@ -5,4 +5,4 @@ publish: true
 page_title: Telerik Friends Sample App for NativeScript | Telerik Platform
 description: A full-featured social demo app that shows how to integrate a large gamut of Telerik Platform services into a multi-platform NativeScript application.
 tags: NativeScript, Native app, Sample App, Application, iOS, Android, JavaScript, BaaS, mBaaS, Social, Analytics
-repo_kind: "Hybrid"
+repo_kind: "NativeScript"


### PR DESCRIPTION
The repo kind is set to Hybrid but it should be NativeScript. This has been reported by Ignacio Fuentes on Slack.

@boevski or @AntonDobrev, please, take a look at this PR so we can push it forward. The repo kind has been set according to the repo_kind logic [here](https://github.com/telerik/tap-samples-docs/blob/master/_plugins/samples_generator.rb).